### PR TITLE
fix: 修复<a>中href指向当前博客，却在新窗口打开的问题

### DIFF
--- a/页尾.html
+++ b/页尾.html
@@ -242,7 +242,12 @@
         setAtarget: function() {
             // 博客内的链接在新窗口打开
             $("#cnblogs_post_body a").each(function(){
-                this.target = "_blank";
+                if (this.href.indexOf(window.location.href === 0)) {
+                    // 如果 url 指向当前博客
+                    // 不要在新窗口打开
+                } else {
+                    this.target = "_blank";
+                }
             }) 
         },
         setContent: function() {


### PR DESCRIPTION
如果博主在 markdown 书写时添加了 [ToC]，会使得新生成的 HTML 中，目录中的 <a> 的 href 指向发布的文章，此时读者点击 [ToC] 中的链接，是不希望在新的标签页中打开的。

如果读者真的有分屏阅读的需求，会自行复制粘贴 url，并创建新的标签页打开。